### PR TITLE
Fix bug when ['in'] is 0

### DIFF
--- a/Controller/APIController.php
+++ b/Controller/APIController.php
@@ -50,7 +50,7 @@ class APIController extends Controller
 
         if (is_array($intervals)){
             foreach ($intervals as $interval){
-                if($interval['in'] && $interval['out']){
+                if(isset($interval['in']) && isset($interval['out'])){
                     $this->saveAction($request, $videoID, $interval['in'], $interval['out']);
                 }
             }


### PR DESCRIPTION
In PHP, `0` is `false`:

```php
php > var_dump((bool)0);
bool(false)
```